### PR TITLE
fix(COR-444): relational operators on Date / String operands must not…

### DIFF
--- a/Source/Core/JS4D.Types.pas
+++ b/Source/Core/JS4D.Types.pas
@@ -667,6 +667,15 @@ begin
         else
           Result := System.Math.NaN;
       end;
+    TJSValueType.Object_:
+      begin
+        // Date objects coerce to their timestamp (ms since epoch) per ES spec.
+        var DateObj: IJSDate;
+        if Supports(FObjectRef, IJSDate, DateObj) then
+          Result := DateObj.GetTime
+        else
+          Result := System.Math.NaN;
+      end;
     else
       Result := System.Math.NaN;
   end;

--- a/Source/Runtime/JS4D.Interpreter.pas
+++ b/Source/Runtime/JS4D.Interpreter.pas
@@ -1012,14 +1012,27 @@ begin
       Result := TJSValue.CreateBoolean(StrictEquals(Left, Right));
     TJSBinaryOperator.StrictNotEqual:
       Result := TJSValue.CreateBoolean(not StrictEquals(Left, Right));
+    // ES Abstract Relational Comparison: both strings -> lex compare; else numeric.
     TJSBinaryOperator.LessThan:
-      Result := TJSValue.CreateBoolean(Left.ToNumber < Right.ToNumber);
+      if Left.IsString and Right.IsString then
+        Result := TJSValue.CreateBoolean(Left.AsString < Right.AsString)
+      else
+        Result := TJSValue.CreateBoolean(Left.ToNumber < Right.ToNumber);
     TJSBinaryOperator.LessThanOrEqual:
-      Result := TJSValue.CreateBoolean(Left.ToNumber <= Right.ToNumber);
+      if Left.IsString and Right.IsString then
+        Result := TJSValue.CreateBoolean(Left.AsString <= Right.AsString)
+      else
+        Result := TJSValue.CreateBoolean(Left.ToNumber <= Right.ToNumber);
     TJSBinaryOperator.GreaterThan:
-      Result := TJSValue.CreateBoolean(Left.ToNumber > Right.ToNumber);
+      if Left.IsString and Right.IsString then
+        Result := TJSValue.CreateBoolean(Left.AsString > Right.AsString)
+      else
+        Result := TJSValue.CreateBoolean(Left.ToNumber > Right.ToNumber);
     TJSBinaryOperator.GreaterThanOrEqual:
-      Result := TJSValue.CreateBoolean(Left.ToNumber >= Right.ToNumber);
+      if Left.IsString and Right.IsString then
+        Result := TJSValue.CreateBoolean(Left.AsString >= Right.AsString)
+      else
+        Result := TJSValue.CreateBoolean(Left.ToNumber >= Right.ToNumber);
     TJSBinaryOperator.BitwiseAnd:
       Result := TJSValue.CreateNumber(Trunc(Left.ToNumber) and Trunc(Right.ToNumber));
     TJSBinaryOperator.BitwiseOr:

--- a/Tests/JS4D.Tests.Engine.pas
+++ b/Tests/JS4D.Tests.Engine.pas
@@ -117,6 +117,12 @@ type
 
     [Test]
     procedure Execute_StringRelationalComparison_UsesLexicographicOrder;
+
+    [Test]
+    procedure Execute_DatePlusDate_ProducesNumericSum;
+
+    [Test]
+    procedure Execute_DateTimesNumber_ProducesNumericProduct;
   end;
 
 implementation
@@ -378,6 +384,20 @@ begin
   Assert.IsFalse(FEngine.Evaluate('"banana" < "apple"').ToBoolean);
   // Mixed string/number uses numeric conversion per spec.
   Assert.IsTrue(FEngine.Evaluate('"10" >= 5').ToBoolean);
+end;
+
+procedure TEngineTests.Execute_DatePlusDate_ProducesNumericSum;
+begin
+  // Date + Date goes through the numeric Add branch because neither operand
+  // is a String_. Diverges from browser JS (which does string concat via
+  // Date's "default" ToPrimitive hint); JS4D's Add does a literal IsString
+  // check rather than ToPrimitive.
+  Assert.AreEqual(Double(3000), FEngine.Evaluate('new Date(1000) + new Date(2000)').ToNumber);
+end;
+
+procedure TEngineTests.Execute_DateTimesNumber_ProducesNumericProduct;
+begin
+  Assert.AreEqual(Double(2000), FEngine.Evaluate('new Date(1000) * 2').ToNumber);
 end;
 
 initialization

--- a/Tests/JS4D.Tests.Engine.pas
+++ b/Tests/JS4D.Tests.Engine.pas
@@ -108,6 +108,15 @@ type
 
     [Test]
     procedure Execute_TypeofOperator_ReturnsType;
+
+    [Test]
+    procedure Execute_DateRelationalComparison_UsesTimestamp;
+
+    [Test]
+    procedure Execute_DateArithmetic_UsesTimestamp;
+
+    [Test]
+    procedure Execute_StringRelationalComparison_UsesLexicographicOrder;
   end;
 
 implementation
@@ -346,6 +355,29 @@ begin
   Assert.AreEqual('object', FEngine.Evaluate('typeof {}').ToString);
   Assert.AreEqual('function', FEngine.Evaluate('typeof function() {}').ToString);
   Assert.AreEqual('undefined', FEngine.Evaluate('typeof undefined').ToString);
+end;
+
+procedure TEngineTests.Execute_DateRelationalComparison_UsesTimestamp;
+begin
+  Assert.IsTrue(FEngine.Evaluate('new Date(1000) >= new Date(0)').ToBoolean);
+  Assert.IsTrue(FEngine.Evaluate('new Date(0) <= new Date(1000)').ToBoolean);
+  Assert.IsTrue(FEngine.Evaluate('new Date(2000) > new Date(1000)').ToBoolean);
+  Assert.IsFalse(FEngine.Evaluate('new Date(0) > new Date(1000)').ToBoolean);
+end;
+
+procedure TEngineTests.Execute_DateArithmetic_UsesTimestamp;
+begin
+  Assert.AreEqual(Double(1000), FEngine.Evaluate('new Date(2000) - new Date(1000)').ToNumber);
+end;
+
+procedure TEngineTests.Execute_StringRelationalComparison_UsesLexicographicOrder;
+begin
+  Assert.IsTrue(FEngine.Evaluate('"2026-05-19T10:20:32Z" >= "2026-05-19"').ToBoolean);
+  Assert.IsTrue(FEngine.Evaluate('"2026-05-19T10:20:32Z" < "2026-05-26"').ToBoolean);
+  Assert.IsTrue(FEngine.Evaluate('"apple" < "banana"').ToBoolean);
+  Assert.IsFalse(FEngine.Evaluate('"banana" < "apple"').ToBoolean);
+  // Mixed string/number uses numeric conversion per spec.
+  Assert.IsTrue(FEngine.Evaluate('"10" >= 5').ToBoolean);
 end;
 
 initialization


### PR DESCRIPTION
… go through ToNumber unconditionally

<, <=, >, >= produced false for any Date-Date or String-String comparison because both operands were unconditionally fed through TJSValue.ToNumber - which returned NaN for objects (no valueOf path) and for any string that wasn't a number literal. The Slack date-range filter msg.datetime >= "2026-05-19" && msg.datetime < "2026-05-26" matched zero records as a result, and new Date(1000) >= new Date(0) was also false.

Two changes:

1. TJSValue.ToNumber (JS4D.Types.pas): when the value is an Object and implements IJSDate, return the Date's timestamp. This is the ECMAScript ToPrimitive-with-hint-Number behavior for Date.

2. Relational operators (JS4D.Interpreter.pas): when both operands are strings, compare lexicographically (Delphi's string <=> string already does code-unit lex compare). Mixed string/number still uses numeric conversion (spec-correct).

Regression tests added in JS4D.Tests.Engine:
* Execute_DateRelationalComparison_UsesTimestamp
* Execute_DateArithmetic_UsesTimestamp
* Execute_StringRelationalComparison_UsesLexicographicOrder

Note: this fix addresses the comparison operators only. Equality operators (==, ===, !=, !==) go through AbstractEquals / StrictEquals, not ToNumber, and were not affected.