### PR TITLE
fix(COR-446): TJSObject preserves insertion order of string keys

### DIFF
--- a/Source/Core/JS4D.Types.pas
+++ b/Source/Core/JS4D.Types.pas
@@ -240,6 +240,7 @@ type
   TJSObjectImpl = class(TInterfacedObject, IJSObject)
   private
     FProperties: TDictionary<string, TJSPropertyDescriptor>;
+    FOrderedKeys: TList<string>;
     FPrototype: IJSObject;
     FFrozen: Boolean;
     FSealed: Boolean;
@@ -791,6 +792,7 @@ constructor TJSObjectImpl.Create;
 begin
   inherited Create;
   FProperties := TDictionary<string, TJSPropertyDescriptor>.Create;
+  FOrderedKeys := TList<string>.Create;
   FFrozen := False;
   FSealed := False;
   FExtensible := True;
@@ -812,6 +814,7 @@ begin
 
   FProperties.Clear;
   FProperties.Free;
+  FOrderedKeys.Free;
   inherited;
 end;
 
@@ -865,6 +868,7 @@ begin
 
     Descriptor := TJSPropertyDescriptor.Create(Value);
     FProperties.Add(Name, Descriptor);
+    FOrderedKeys.Add(Name);
   end;
 end;
 
@@ -883,12 +887,17 @@ begin
     Descriptor := TJSPropertyDescriptor.Create(Value);
     Descriptor.Configurable := False;
     FProperties.Add(Name, Descriptor);
+    FOrderedKeys.Add(Name);
   end;
 end;
 
 procedure TJSObjectImpl.DeleteProperty(const Name: string);
 begin
-  FProperties.Remove(Name);
+  if FProperties.ContainsKey(Name) then
+  begin
+    FProperties.Remove(Name);
+    FOrderedKeys.Remove(Name);
+  end;
 end;
 
 function TJSObjectImpl.IsPropertyConfigurable(const Name: string): Boolean;
@@ -905,7 +914,7 @@ end;
 
 function TJSObjectImpl.GetOwnPropertyNames: TArray<string>;
 begin
-  Result := FProperties.Keys.ToArray;
+  Result := FOrderedKeys.ToArray;
 end;
 
 function TJSObjectImpl.IsFrozen: Boolean;
@@ -987,6 +996,7 @@ begin
       Exit;
 
     FProperties.Add(Name, Descriptor);
+    FOrderedKeys.Add(Name);
   end;
 end;
 

--- a/Tests/JS4D.Tests.Builtins.pas
+++ b/Tests/JS4D.Tests.Builtins.pas
@@ -6,6 +6,7 @@ interface
 
 uses
   System.Math,
+  System.SysUtils,
   DUnitX.TestFramework,
   JS4D.Types,
   JS4D.Engine;
@@ -213,6 +214,18 @@ type
 
     [Test]
     procedure Object_HasOwnProperty_ReturnsFalse;
+
+    [Test]
+    procedure Object_Keys_PreservesInsertionOrder;
+
+    [Test]
+    procedure Object_Keys_PreservesInsertionOrderAfterReassign;
+
+    [Test]
+    procedure Object_Keys_PreservesInsertionOrderAfterDeleteAndReadd;
+
+    [Test]
+    procedure Object_Keys_IntegerLikeKeys_PreserveInsertionOrder;
   end;
 
   [TestFixture]
@@ -244,6 +257,15 @@ type
 
     [Test]
     procedure JSON_RoundTrip_PreservesData;
+
+    [Test]
+    procedure JSON_Stringify_PreservesInsertionOrderOfKeys;
+
+    [Test]
+    procedure JSON_Stringify_PreservesOrderAfterReassign;
+
+    [Test]
+    procedure JSON_Stringify_PreservesOrderForDynamicallyAddedKeys;
   end;
 
   [TestFixture]
@@ -1101,6 +1123,38 @@ begin
   Assert.IsFalse(Result.AsBoolean);
 end;
 
+procedure TObjectMethodsTests.Object_Keys_PreservesInsertionOrder;
+begin
+  FEngine.Execute('var obj = { b: 1, a: 2, c: 3 };');
+  const Result = FEngine.Evaluate('Object.keys(obj).join(",")');
+  Assert.AreEqual('b,a,c', Result.AsString);
+end;
+
+procedure TObjectMethodsTests.Object_Keys_PreservesInsertionOrderAfterReassign;
+begin
+  FEngine.Execute('var obj = { b: 1, a: 2, c: 3 };');
+  FEngine.Execute('obj.b = 99;');
+  const Result = FEngine.Evaluate('Object.keys(obj).join(",")');
+  Assert.AreEqual('b,a,c', Result.AsString);
+end;
+
+procedure TObjectMethodsTests.Object_Keys_PreservesInsertionOrderAfterDeleteAndReadd;
+begin
+  FEngine.Execute('var obj = { a: 1, b: 2, c: 3 };');
+  FEngine.Execute('delete obj.b;');
+  FEngine.Execute('obj.b = 20;');
+  const Result = FEngine.Evaluate('Object.keys(obj).join(",")');
+  Assert.AreEqual('a,c,b', Result.AsString);
+end;
+
+procedure TObjectMethodsTests.Object_Keys_IntegerLikeKeys_PreserveInsertionOrder;
+begin
+  FEngine.Execute('var obj = {};');
+  FEngine.Execute('obj["3"] = 3; obj["1"] = 1; obj["2"] = 2;');
+  const Result = FEngine.Evaluate('Object.keys(obj).join(",")');
+  Assert.AreEqual('3,1,2', Result.AsString);
+end;
+
 procedure TJSONTests.Setup;
 begin
   FEngine := TJSEngine.Create;
@@ -1156,6 +1210,59 @@ begin
   const YResult = FEngine.Evaluate('parsed.y');
   Assert.AreEqual(Double(42), XResult.AsNumber);
   Assert.AreEqual('test', YResult.AsString);
+end;
+
+procedure TJSONTests.JSON_Stringify_PreservesInsertionOrderOfKeys;
+begin
+  // Assert key positions (not numeric formatting — engine emits "1" or "1.0").
+  FEngine.Execute('var obj = { b: 1, a: 2, c: 3 };');
+  const Result = FEngine.Evaluate('JSON.stringify(obj)');
+  const JsonStr = Result.AsString;
+  Assert.IsTrue(Pos('"b"', JsonStr) < Pos('"a"', JsonStr),
+    Format('"b" should precede "a" in: %s', [JsonStr]));
+  Assert.IsTrue(Pos('"a"', JsonStr) < Pos('"c"', JsonStr),
+    Format('"a" should precede "c" in: %s', [JsonStr]));
+end;
+
+procedure TJSONTests.JSON_Stringify_PreservesOrderAfterReassign;
+begin
+  FEngine.Execute('var obj = { first: 1, second: 2, third: 3 };');
+  FEngine.Execute('obj.first = 99;');
+  const Result = FEngine.Evaluate('JSON.stringify(obj)');
+  const JsonStr = Result.AsString;
+  Assert.IsTrue(Pos('"first"', JsonStr) < Pos('"second"', JsonStr),
+    Format('"first" should still precede "second" after reassign in: %s', [JsonStr]));
+  Assert.IsTrue(Pos('"second"', JsonStr) < Pos('"third"', JsonStr),
+    Format('"second" should still precede "third" after reassign in: %s', [JsonStr]));
+  // Value of reassigned key must be present.
+  Assert.IsTrue(Pos('99', JsonStr) > 0);
+end;
+
+procedure TJSONTests.JSON_Stringify_PreservesOrderForDynamicallyAddedKeys;
+begin
+  FEngine.Execute(
+    'var rij = { materiaal: "Autobanden" };' +
+    'var maanden = ["2025-01","2025-02","2025-03","2025-04","2025-05","2025-06",' +
+    '"2025-07","2025-08","2025-09","2025-10","2025-11","2025-12"];' +
+    'maanden.forEach(function(m, i) { rij[m] = i + 1; });' +
+    'rij.totaal = 99;'
+  );
+  const Result = FEngine.Evaluate('JSON.stringify(rij)');
+  const JsonStr = Result.AsString;
+
+  // materiaal must come first, totaal last, months in chronological order.
+  Assert.IsTrue(Pos('"materiaal"', JsonStr) < Pos('"2025-01"', JsonStr),
+    Format('"materiaal" must come before "2025-01" in: %s', [JsonStr]));
+  Assert.IsTrue(Pos('"2025-12"', JsonStr) < Pos('"totaal"', JsonStr),
+    Format('"totaal" must come after "2025-12" in: %s', [JsonStr]));
+  // Each month must precede the next.
+  for var I := 1 to 11 do
+  begin
+    var ThisKey: string := Format('"2025-%.2d"', [I]);
+    var NextKey: string := Format('"2025-%.2d"', [I + 1]);
+    Assert.IsTrue(Pos(ThisKey, JsonStr) < Pos(NextKey, JsonStr),
+      Format('%s must precede %s in: %s', [ThisKey, NextKey, JsonStr]));
+  end;
 end;
 
 procedure TGlobalFunctionsTests.Setup;


### PR DESCRIPTION
Per ECMAScript 2015+ Object.keys / for-in / JSON.stringify must enumerate string keys in the order they were first added to the object (and reassigning an existing key keeps its slot). TJSObjectImpl stored properties in a TDictionary<string, ...>, which itterates in hash-bucket order. Downstream JS code that relied on insertion order (notably LLM-generated table-shaped output via JSON.stringify) saw scrambled keys.

Real-world impact: in Codolex AI analyze_data, the LLM-built rows like { materiaal, '2025-01'..'2025-12', totaal } came out with keys in arbitrary order. When the LLM rendered the resulting JSON back into a markdown table it placed the 'totaal' value into the November column (12th non-materiaal position) and re-summed the inflated row, doubling the year totals.

Add a parallel insertion-order TList<string> to TJSObjectImpl. Lookup stays on the dictionary (O(1)). Enumeration via GetOwnPropertyNames (used by JSON.stringify, Object.keys, Object.values, Object.entries, for-in) now returns FOrderedKeys.

Tests added in TJSONTests and TObjectMethodsTests covering:
  * key order preserved after reassign
  * key order preserved after delete+readd (readded key goes to the end)
  * integer-like keys ("3","1","2") preserved in insertion order
  * regression test mirroring the analyze_data row shape from greenwaste

All 226 tests pass.