### PR TITLE
Add Linux64 platform (v1.0.1)

### DIFF
--- a/GDK.Javascript4D.dspec
+++ b/GDK.Javascript4D.dspec
@@ -2,7 +2,7 @@
 min dpm client version: 1.0.0
 metadata:
   id: GDK.Javascript4D
-  version: 1.0.0
+  version: 1.0.1
   description: 'Native JavaScript (ECMAScript 5.1) parser and interpreter written in Delphi. Execute JavaScript directly from your Delphi applications.'
   authors:
     - GDK Software
@@ -25,6 +25,7 @@ targetPlatforms:
     platforms:
       - win32
       - win64
+      - linux64
 templates:
   - name: default
     source:


### PR DESCRIPTION
Adds `linux64` to the target platforms and bumps to 1.0.1. Sources compile cleanly for Linux64 (verified with the Delphi 13.0 Linux compiler).