### PR TITLE
Add garbage collection to fix unbounded memory growth (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ begin
 end;
 ```
 
+## Memory Management
+
+Executing a script repeatedly in a long-lived engine (for example a render loop at 30 FPS) accumulates the scopes, functions and parsed programs created by each run. Call `CollectGarbage` to reclaim everything that is no longer reachable from global state, without recreating the engine and losing your globals:
+
+```pascal
+while Running do
+begin
+  Engine.Execute(FrameScript);
+  Engine.CollectGarbage;
+end;
+```
+
+Anything still referenced from a global variable, including closures, survives collection. Only script functions and scopes that the host retains directly (raw values held outside the engine) should not be relied upon across a collection; keep persistent state in globals.
+
 ## Supported JavaScript Features
 
 ### Core Language

--- a/Source/API/JS4D.Engine.pas
+++ b/Source/API/JS4D.Engine.pas
@@ -46,6 +46,7 @@ type
 
     function Execute(const Source: string): TJSValue;
     function Evaluate(const Expression: string): TJSValue;
+    procedure CollectGarbage;
 
     procedure RegisterFunction(const Name: string; const Func: TNativeFunction);
     procedure SetVariable(const Name: string; const Value: TJSValue);
@@ -315,6 +316,29 @@ begin
     Result := FInterpreter.Execute(Program_);
   finally
     Parser.Free;
+  end;
+end;
+
+procedure TJSEngine.CollectGarbage;
+begin
+  FInterpreter.CollectGarbage;
+
+  const LiveSet = TDictionary<TObject, Byte>.Create;
+  try
+    for var LiveProgram in FInterpreter.LivePrograms do
+      LiveSet.AddOrSetValue(LiveProgram, 0);
+
+    for var Index := FPrograms.Count - 1 downto 0 do
+    begin
+      const Program_ = FPrograms[Index];
+      if not LiveSet.ContainsKey(Program_) then
+      begin
+        Program_.Free;
+        FPrograms.Delete(Index);
+      end;
+    end;
+  finally
+    LiveSet.Free;
   end;
 end;
 

--- a/Source/Core/JS4D.Types.pas
+++ b/Source/Core/JS4D.Types.pas
@@ -89,6 +89,8 @@ type
     function Resolve(const Name: string): IJSScope;
     function GetParent: IJSScope;
     procedure Clear;
+    function GetOwnVariables: TArray<TJSValue>;
+    procedure ReleaseReferences;
     property Parent: IJSScope read GetParent;
   end;
 

--- a/Source/Runtime/JS4D.Interpreter.pas
+++ b/Source/Runtime/JS4D.Interpreter.pas
@@ -32,6 +32,8 @@ type
     procedure DeclareVariable(const Name: string; const Value: TJSValue);
     function Resolve(const Name: string): IJSScope;
     procedure Clear;
+    function GetOwnVariables: TArray<TJSValue>;
+    procedure ReleaseReferences;
 
     property Parent: IJSScope read GetParent;
   end;
@@ -70,11 +72,15 @@ type
     FGlobalObject: IJSObject;
     FFunctionRegistry: TList<IJSFunction>;
     FScopeRegistry: TList<IJSScope>;
+    FFunctionPrograms: TDictionary<Pointer, TObject>;
+    FCurrentProgram: TObject;
 
     procedure PushScope;
     procedure PopScope;
     procedure RegisterFunction(const Func: IJSFunction);
     procedure RegisterScope(const Scope: IJSScope);
+    procedure GCMark(const Item: IInterface; const Live: TDictionary<Pointer, Byte>; const Work: TList<IInterface>);
+    procedure GCMarkValue(const Value: TJSValue; const Live: TDictionary<Pointer, Byte>; const Work: TList<IInterface>);
 
     function Visit(const Node: TJSASTNode): TJSValue;
 
@@ -127,6 +133,8 @@ type
     procedure RegisterNativeFunction(const Name: string; const Func: TNativeFunction);
     procedure SetGlobalVariable(const Name: string; const Value: TJSValue);
     function GetGlobalVariable(const Name: string): TJSValue;
+    procedure CollectGarbage;
+    function LivePrograms: TArray<TObject>;
 
     property GlobalScope: IJSScope read FGlobalScope;
   end;
@@ -190,6 +198,23 @@ begin
     end;
   end;
 
+  FVariables.Clear;
+  FParent := nil;
+end;
+
+function TJSScope.GetOwnVariables: TArray<TJSValue>;
+begin
+  SetLength(Result, FVariables.Count);
+  var Index := 0;
+  for var Pair in FVariables do
+  begin
+    Result[Index] := Pair.Value;
+    Inc(Index);
+  end;
+end;
+
+procedure TJSScope.ReleaseReferences;
+begin
   FVariables.Clear;
   FParent := nil;
 end;
@@ -272,6 +297,8 @@ begin
   inherited Create;
   FFunctionRegistry := TList<IJSFunction>.Create;
   FScopeRegistry := TList<IJSScope>.Create;
+  FFunctionPrograms := TDictionary<Pointer, TObject>.Create;
+  FCurrentProgram := nil;
   FGlobalScope := TJSScope.Create(nil);
   FScopeRegistry.Add(FGlobalScope);
   FCurrentScope := FGlobalScope;
@@ -293,6 +320,7 @@ begin
     Scope.Clear;
   end;
   FScopeRegistry.Free;
+  FFunctionPrograms.Free;
 
   FCurrentScope := nil;
   FGlobalScope := nil;
@@ -305,6 +333,7 @@ procedure TJSInterpreter.RegisterFunction(const Func: IJSFunction);
 begin
   if not FFunctionRegistry.Contains(Func) then
     FFunctionRegistry.Add(Func);
+  FFunctionPrograms.AddOrSetValue(Pointer(Func as IInterface), FCurrentProgram);
 end;
 
 procedure TJSInterpreter.RegisterScope(const Scope: IJSScope);
@@ -326,6 +355,7 @@ end;
 
 function TJSInterpreter.Execute(const Program_: TJSProgram): TJSValue;
 begin
+  FCurrentProgram := Program_;
   Result := Visit(Program_);
 end;
 
@@ -1778,6 +1808,121 @@ end;
 function TJSInterpreter.GetGlobalVariable(const Name: string): TJSValue;
 begin
   Result := FGlobalScope.GetVariable(Name);
+end;
+
+procedure TJSInterpreter.GCMark(const Item: IInterface; const Live: TDictionary<Pointer, Byte>; const Work: TList<IInterface>);
+begin
+  if Item = nil then
+    Exit;
+
+  const Id = Pointer(Item as IInterface);
+  if Live.ContainsKey(Id) then
+    Exit;
+
+  Live.Add(Id, 0);
+  Work.Add(Item);
+end;
+
+procedure TJSInterpreter.GCMarkValue(const Value: TJSValue; const Live: TDictionary<Pointer, Byte>; const Work: TList<IInterface>);
+begin
+  if Value.IsObject then
+    GCMark(Value.ToObject, Live, Work);
+end;
+
+procedure TJSInterpreter.CollectGarbage;
+begin
+  const Live = TDictionary<Pointer, Byte>.Create;
+  const Work = TList<IInterface>.Create;
+  try
+    GCMark(FGlobalScope, Live, Work);
+    GCMark(FCurrentScope, Live, Work);
+    GCMark(FThisValue, Live, Work);
+    GCMark(FGlobalObject, Live, Work);
+    for var Func in FFunctionRegistry do
+      if Func.IsNative then
+        GCMark(Func, Live, Work);
+
+    while Work.Count > 0 do
+    begin
+      const Item = Work.Last;
+      Work.Delete(Work.Count - 1);
+
+      var Scope: IJSScope;
+      var Func: IJSFunction;
+      var Arr: IJSArray;
+      var Obj: IJSObject;
+
+      if Supports(Item, IJSScope, Scope) then
+      begin
+        GCMark(Scope.Parent, Live, Work);
+        for var Value in Scope.GetOwnVariables do
+          GCMarkValue(Value, Live, Work);
+      end
+      else if Supports(Item, IJSFunction, Func) then
+      begin
+        GCMark(Func.ClosureScope, Live, Work);
+        GCMark(Func.Prototype, Live, Work);
+        for var PropName in Func.GetOwnPropertyNames do
+          GCMarkValue(Func.GetProperty(PropName), Live, Work);
+      end
+      else if Supports(Item, IJSArray, Arr) then
+      begin
+        for var ElementIndex := 0 to Arr.Length - 1 do
+          GCMarkValue(Arr.Elements[ElementIndex], Live, Work);
+        GCMark(Arr.Prototype, Live, Work);
+        for var PropName in Arr.GetOwnPropertyNames do
+          GCMarkValue(Arr.GetProperty(PropName), Live, Work);
+      end
+      else if Supports(Item, IJSObject, Obj) then
+      begin
+        GCMark(Obj.Prototype, Live, Work);
+        for var PropName in Obj.GetOwnPropertyNames do
+          GCMarkValue(Obj.GetProperty(PropName), Live, Work);
+      end;
+    end;
+
+    for var Index := FFunctionRegistry.Count - 1 downto 0 do
+    begin
+      const Func = FFunctionRegistry[Index];
+      if not Live.ContainsKey(Pointer(Func as IInterface)) then
+      begin
+        FFunctionPrograms.Remove(Pointer(Func as IInterface));
+        Func.ClosureScope := nil;
+        Func.NativeFunction := nil;
+        FFunctionRegistry.Delete(Index);
+      end;
+    end;
+
+    for var Index := FScopeRegistry.Count - 1 downto 0 do
+    begin
+      const Scope = FScopeRegistry[Index];
+      if not Live.ContainsKey(Pointer(Scope as IInterface)) then
+      begin
+        Scope.ReleaseReferences;
+        FScopeRegistry.Delete(Index);
+      end;
+    end;
+  finally
+    Work.Free;
+    Live.Free;
+  end;
+end;
+
+function TJSInterpreter.LivePrograms: TArray<TObject>;
+begin
+  SetLength(Result, 0);
+  const Seen = TDictionary<TObject, Byte>.Create;
+  try
+    for var Pair in FFunctionPrograms do
+      if (Pair.Value <> nil) and not Seen.ContainsKey(Pair.Value) then
+      begin
+        Seen.Add(Pair.Value, 0);
+        SetLength(Result, Length(Result) + 1);
+        Result[High(Result)] := Pair.Value;
+      end;
+  finally
+    Seen.Free;
+  end;
 end;
 
 end.

--- a/Tests/JS4D.Tests.Engine.pas
+++ b/Tests/JS4D.Tests.Engine.pas
@@ -6,6 +6,7 @@ interface
 
 uses
   DUnitX.TestFramework,
+  System.SysUtils,
   JS4D.Types,
   JS4D.Engine;
 
@@ -14,6 +15,7 @@ type
   TEngineTests = class
   private
     FEngine: TJSEngine;
+    function AllocatedBytes: NativeInt;
 
   public
     [Setup]
@@ -123,6 +125,16 @@ type
 
     [Test]
     procedure Execute_DateTimesNumber_ProducesNumericProduct;
+    [Test]
+    procedure Execute_RepeatedInSameEngine_DoesNotLeakMemory;
+
+    [Test]
+    procedure CollectGarbage_ClosureInGlobal_SurvivesAndWorks;
+    [Test]
+    procedure CollectGarbage_GlobalState_Persists;
+    [Test]
+    procedure CollectGarbage_Builtins_StillWork;
+
   end;
 
 implementation
@@ -398,6 +410,64 @@ end;
 procedure TEngineTests.Execute_DateTimesNumber_ProducesNumericProduct;
 begin
   Assert.AreEqual(Double(2000), FEngine.Evaluate('new Date(1000) * 2').ToNumber);
+end;
+
+function TEngineTests.AllocatedBytes: NativeInt;
+begin
+  var State: TMemoryManagerState;
+  GetMemoryManagerState(State);
+  Result := State.TotalAllocatedMediumBlockSize + State.TotalAllocatedLargeBlockSize;
+  for var SmallState in State.SmallBlockTypeStates do
+    Result := Result + NativeInt(SmallState.UseableBlockSize) * NativeInt(SmallState.AllocatedBlockCount);
+end;
+
+procedure TEngineTests.Execute_RepeatedInSameEngine_DoesNotLeakMemory;
+begin
+  const Script = 'function make(n) { var f = function() { return n * 2; }; return f(); } make(21);';
+
+  for var I := 1 to 200 do
+    FEngine.Execute(Script);
+
+  const Before = AllocatedBytes;
+  for var I := 1 to 4000 do
+  begin
+    FEngine.Execute(Script);
+    FEngine.CollectGarbage;
+  end;
+  const Growth = AllocatedBytes - Before;
+
+  Assert.IsTrue(Growth < 512 * 1024,
+    Format('Heap grew by %d bytes over 4000 executions in one engine (expected < 512 KB): scopes/functions are retained for the engine lifetime', [Growth]));
+end;
+
+procedure TEngineTests.CollectGarbage_ClosureInGlobal_SurvivesAndWorks;
+begin
+  FEngine.Execute('var counter = (function() { var n = 0; return function() { n = n + 1; return n; }; })();');
+  FEngine.Execute('counter();');
+  FEngine.CollectGarbage;
+
+  const Result = FEngine.Evaluate('counter()');
+
+  Assert.AreEqual(Double(2), Result.ToNumber, 'Closure stored in a global must survive collection with its captured state');
+end;
+
+procedure TEngineTests.CollectGarbage_GlobalState_Persists;
+begin
+  FEngine.Execute('var data = { total: 42 };');
+  FEngine.CollectGarbage;
+
+  const Result = FEngine.Evaluate('data.total');
+
+  Assert.AreEqual(Double(42), Result.ToNumber);
+end;
+
+procedure TEngineTests.CollectGarbage_Builtins_StillWork;
+begin
+  FEngine.CollectGarbage;
+
+  const Result = FEngine.Evaluate('Math.max(3, 7)');
+
+  Assert.AreEqual(Double(7), Result.ToNumber);
 end;
 
 initialization


### PR DESCRIPTION
Fixes #4.

## Problem
Running a script repeatedly in one long-lived engine (e.g. a 30 FPS loop) grew memory unbounded (~200-400 KB/s reported; ~2.4 KB per `Execute` measured). Recreating the engine reclaimed it but lost all state.

## Cause
- The interpreter registered **every** scope (`PushScope`) and function it ever created in `FScopeRegistry`/`FFunctionRegistry`; `PopScope` never unregistered, and both were only freed in the destructor. They exist to break closure reference cycles (`function.ClosureScope` <-> `scope` holding the function) that refcounting cannot.
- The engine kept every parsed program AST in `FPrograms` forever.

## Fix
Adds `TJSEngine.CollectGarbage`: a mark-sweep collector.
1. **Mark** everything reachable from roots: global scope, current scope, `this`, the global object and native builtins, tracing scope variables, object/array properties, prototypes and closures.
2. **Sweep** unreachable scopes and functions (breaking their own references only, never touching a live function held by a garbage scope), and free programs no longer referenced by any surviving function.

Persistent state and closures kept in globals survive collection. Intended to be called per frame; no engine recreation, no lost globals.

## Tests
- Memory-growth test: 4000 executions in one engine stay bounded (< 512 KB) with periodic `CollectGarbage` (was ~9.8 MB without).
- Correctness: a closure stored in a global survives collection and keeps its captured state; global object state persists; builtins keep working.
- Full suite: **230 tests, 0 failures, 0 leaks.**